### PR TITLE
Remove -march=native from COMMON_CFLAGS

### DIFF
--- a/lucet-builtins/Makefile
+++ b/lucet-builtins/Makefile
@@ -7,7 +7,7 @@ LIBBUILTINS_OBJS:=$(addprefix build/, \
 	strcmp.o \
 	strlen.o )
 
-COMMON_CFLAGS:= --std=gnu99 -Ofast -Wall -Werror -march=native -fPIC \
+COMMON_CFLAGS:= --std=gnu99 -Ofast -Wall -Werror -fPIC \
 	-I../lucet-runtime/include
 
 default: build/libbuiltins.so


### PR DESCRIPTION
We use lucet in Tor Browser, and [found](https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/issues/40262) that the build is failing on some hardware with the error:
```
make[1]: Entering directory '/var/tmp/build/lucetc/lucet-builtins'
/var/tmp/dist/clang/bin/clang --std=gnu99 -Ofast -Wall -Werror -march=native -fPIC -I../lucet-runtime/include -c src/memcpy.c -o build/memcpy.o
error: unknown target CPU 'pentium2'
note: valid target CPU values are: nocona, core2, penryn, bonnell, atom, silvermont, slm, goldmont, goldmont-plus, tremont, nehalem, corei7, westmere, sandybridge, corei7-avx, ivybridge, core-avx-i, haswell, core-avx2, broadwell, skylake, skylake-avx512, skx, cascadelake, cooperlake, cannonlake, icelake-client, icelake-server, knl, knm, k8, athlon64, athlon-fx, opteron, k8-sse3, athlon64-sse3, opteron-sse3, amdfam10, barcelona, btver1, btver2, bdver1, bdver2, bdver3, bdver4, znver1, znver2, x86-64
Makefile:16: recipe for target 'build/memcpy.o' failed
make[1]: *** [build/memcpy.o] Error 1
make[1]: Leaving directory '/var/tmp/build/lucetc/lucet-builtins'
Makefile:11: recipe for target 'build' failed
```

This patch is fixing the issue for us.